### PR TITLE
Version bump to 5.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.6",
+	"version": "5.2.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -7505,9 +7505,9 @@
 			}
 		},
 		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/fstream/-/fstream-1.0.11.tgz?dl=https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"version": "1.0.12",
+			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/fstream/-/fstream-1.0.12.tgz?dl=https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.15",
@@ -10896,22 +10896,10 @@
 			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
 			"dev": true
 		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/lodash.assign/-/lodash.assign-4.2.0.tgz?dl=https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true
-		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz?dl=https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-			"dev": true
-		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz?dl=https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
 		"lodash.debounce": {
@@ -10971,12 +10959,6 @@
 			"version": "4.1.2",
 			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/lodash.memoize/-/lodash.memoize-4.1.2.tgz?dl=https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
-		},
-		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz?dl=https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha1-Y5BX5ybDr72z59QnQcqo1uQzWSc=",
 			"dev": true
 		},
 		"lodash.pick": {
@@ -11776,7 +11758,8 @@
 			"version": "2.12.1",
 			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/nan/-/nan-2.12.1.tgz?dl=https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
 			"integrity": "sha1-exqhk+mqhgV+PHu9CsRI53CSVVI=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -11894,7 +11877,7 @@
 			"integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
 			"dev": true,
 			"requires": {
-				"fstream": "1.0.11",
+				"fstream": "1.0.12",
 				"glob": "7.1.3",
 				"graceful-fs": "4.1.15",
 				"mkdirp": "0.5.1",
@@ -11904,7 +11887,7 @@
 				"request": "2.88.0",
 				"rimraf": "2.6.3",
 				"semver": "5.3.0",
-				"tar": "2.2.1",
+				"tar": "2.2.2",
 				"which": "1.3.1"
 			},
 			"dependencies": {
@@ -11986,9 +11969,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.11.0",
-			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/node-sass/-/node-sass-4.11.0.tgz?dl=https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-			"integrity": "sha1-GD+uw5jpy+k7pDNi4naMqYimNpo=",
+			"version": "4.12.0",
+			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/node-sass/-/node-sass-4.12.0.tgz?dl=https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+			"integrity": "sha1-CRT1MZMjgBFKMMxfpPpjIzol8Bc=",
 			"dev": true,
 			"requires": {
 				"async-foreach": "0.1.3",
@@ -11998,12 +11981,10 @@
 				"get-stdin": "4.0.1",
 				"glob": "7.1.3",
 				"in-publish": "2.0.0",
-				"lodash.assign": "4.2.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.mergewith": "4.6.1",
+				"lodash": "4.17.11",
 				"meow": "3.7.0",
 				"mkdirp": "0.5.1",
-				"nan": "2.12.1",
+				"nan": "2.14.0",
 				"node-gyp": "3.8.0",
 				"npmlog": "4.1.2",
 				"request": "2.88.0",
@@ -12026,6 +12007,12 @@
 					"version": "4.0.1",
 					"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/get-stdin/-/get-stdin-4.0.1.tgz?dl=https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
 					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+					"dev": true
+				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/nan/-/nan-2.14.0.tgz?dl=https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
 					"dev": true
 				}
 			}
@@ -17123,13 +17110,13 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/tar/-/tar-2.2.1.tgz?dl=https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "2.2.2",
+			"resolved": "https://npm.corp.maana.io:443/artifactory/api/npm/npm/tar/-/tar-2.2.2.tgz?dl=https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
 			"dev": true,
 			"requires": {
 				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
+				"fstream": "1.0.12",
 				"inherits": "2.0.3"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.6",
+	"version": "5.2.7",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/maana-io/react-diagrams.git"
@@ -67,7 +67,7 @@
 		"jest": "^22.4.3",
 		"jest-cli": "^22.4.3",
 		"json-beautify": "^1.0.1",
-		"node-sass": "^4.9.0",
+		"node-sass": "^4.12.0",
 		"prettier": "^1.12.1",
 		"puppeteer": "^1.3.0",
 		"raf": "^3.4.0",


### PR DESCRIPTION
Bump the version of node-sass to try to unbreak the team-city job. The team-city server is running Node 12 and this is only supported by node-sass 4.12.0.

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)

Oh and I'm a l33t Hackzor