### PR TITLE
Revert changes made for layout.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.9",
+	"version": "5.2.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.9",
+	"version": "5.2.10",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/maana-io/react-diagrams.git"

--- a/src/models/DiagramModel.ts
+++ b/src/models/DiagramModel.ts
@@ -169,18 +169,40 @@ export class DiagramModel extends BaseEntity<DiagramListener> {
 
 	setZoomLevel(zoom: number) {
 		this.zoom = zoom;
+
+		this.iterateListeners((listener, event) => {
+			if (listener.zoomUpdated) {
+				listener.zoomUpdated({ ...event, zoom: zoom });
+			}
+		});
 	}
 
 	setOffset(offsetX: number, offsetY: number) {
 		this.offsetX = offsetX;
 		this.offsetY = offsetY;
+		this.iterateListeners((listener, event) => {
+			if (listener.offsetUpdated) {
+				listener.offsetUpdated({ ...event, offsetX: offsetX, offsetY: offsetY });
+			}
+		});
 	}
 
 	setOffsetX(offsetX: number) {
 		this.offsetX = offsetX;
+		this.iterateListeners((listener, event) => {
+			if (listener.offsetUpdated) {
+				listener.offsetUpdated({ ...event, offsetX: offsetX, offsetY: this.offsetY });
+			}
+		});
 	}
 	setOffsetY(offsetY: number) {
 		this.offsetY = offsetY;
+
+		this.iterateListeners((listener, event) => {
+			if (listener.offsetUpdated) {
+				listener.offsetUpdated({ ...event, offsetX: this.offsetX, offsetY: this.offsetY });
+			}
+		});
 	}
 
 	getOffsetY() {

--- a/src/widgets/layers/NodeLayerWidget.tsx
+++ b/src/widgets/layers/NodeLayerWidget.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
-import * as _ from "lodash";
-
-import { BaseWidget, BaseWidgetProps } from "../BaseWidget";
-
 import { DiagramEngine } from "../../DiagramEngine";
-import { NodeModel } from "../../models/NodeModel";
+import * as _ from "lodash";
 import { NodeWidget } from "../NodeWidget";
+import { NodeModel } from "../../models/NodeModel";
+import { BaseWidget, BaseWidgetProps } from "../BaseWidget";
 
 export interface NodeLayerProps extends BaseWidgetProps {
 	diagramEngine: DiagramEngine;
 }
 
-export interface NodeLayerState { }
+export interface NodeLayerState {}
 
 export class NodeLayerWidget extends BaseWidget<NodeLayerProps, NodeLayerState> {
 	constructor(props: NodeLayerProps) {
@@ -31,23 +29,6 @@ export class NodeLayerWidget extends BaseWidget<NodeLayerProps, NodeLayerState> 
 	componentDidUpdate() {
 		this.updateNodeDimensions();
 		this.props.diagramEngine.nodesRendered = true;
-
-		const model = this.props.diagramEngine.getDiagramModel();
-
-		model.iterateListeners((listener, event) => {
-			if (listener.zoomUpdated) {
-				listener.zoomUpdated({
-					...event,
-					zoom: model.zoom
-				});
-			} else if (listener.offsetUpdated) {
-				listener.offsetUpdated({
-					...event,
-					offsetX: model.offsetX,
-					offsetY: model.offsetY
-				});
-			}
-		});
 	}
 
 	render() {


### PR DESCRIPTION
They result in spamming the zoom handler when doing any action on the graph which causes unexpected re-renders and slowness in the graph.

This is reverting the changes made that were made by Jim to address layout issues. The changes were pushed directly to master but reference the version bump in this PR: #11 
These changes are no longer needed with the new layout.

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)
