### PR TITLE
Qp 454 improve wheel perf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.10",
+	"version": "5.2.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.10",
+	"version": "5.2.11",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/maana-io/react-diagrams.git"

--- a/src/widgets/BaseWidget.tsx
+++ b/src/widgets/BaseWidget.tsx
@@ -10,6 +10,10 @@ export interface BaseWidgetProps {
 	 * append additional classes
 	 */
 	className?: string;
+	/**
+	 * append additional styles
+	 */
+	style?: object;
 
 	/**
 	 * Additional props to add
@@ -38,7 +42,8 @@ export class BaseWidget<P extends BaseWidgetProps = BaseWidgetProps, S = any> ex
 	getProps(): any {
 		return {
 			...((this.props.extraProps as any) || {}),
-			className: this.getClassName()
+			className: this.getClassName(),
+			style: this.props.style
 		};
 	}
 }


### PR DESCRIPTION
This does a few things with the intention of improving performance of zoom.

- Use an animation frame for wheel events.
- Move the wheel event to addEventListener to fix the warning about calling preventDefault within a passive event handler. See discussion here: https://github.com/facebook/react/issues/6436
- Allow the style attribute to be passed in through props.

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)
