### PR TITLE
QP-504: Make entites render-able again after zoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.12",
+	"version": "5.2.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "maana-react-diagrams",
-	"version": "5.2.12",
+	"version": "5.2.13",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/maana-io/react-diagrams.git"

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -494,7 +494,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 		);
 
 		diagramEngine.enableRepaintEntities([]);
-		this.forceUpdate();
+    this.forceUpdate(() => diagramEngine.clearRepaintEntities());
 	}
 
 	drawSelectionBox() {
@@ -568,7 +568,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 						} else {
 							diagramModel.clearSelection();
 						}
-					} else if(model.model) {
+					} else if (model.model) {
 						//its some or other element, probably want to move it
 						if (!event.shiftKey && !model.model.isSelected()) {
 							diagramModel.clearSelection();

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -144,7 +144,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 
 		if (this.componentRef.current) {
 			this.componentRef.current.addEventListener('wheel', this.onMouseWheel);
-		
+
 			this.props.diagramEngine.setCanvas(this.componentRef.current);
 		}
 
@@ -447,7 +447,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 
 			const {diagramEngine} = this.props
 			const diagramModel = diagramEngine.getDiagramModel()
-			
+
 			// Requesting an animation frame allows the browser to repaint between frames
 			// resulting in a much smoother zooming experience.
 			if (this.lastZoomAnimationFrame) cancelAnimationFrame(this.lastZoomAnimationFrame);

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -494,7 +494,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 		);
 
 		diagramEngine.enableRepaintEntities([]);
-    this.forceUpdate(() => diagramEngine.clearRepaintEntities());
+		this.forceUpdate(() => diagramEngine.clearRepaintEntities());
 	}
 
 	drawSelectionBox() {


### PR DESCRIPTION
Zooming was not clearing the list of render-able entities, so it required a mouse click on the graph to clear them out again.

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)
