### PR TITLE
Qp 510 links not rendering correctly

### DIFF
--- a/src/DiagramEngine.ts
+++ b/src/DiagramEngine.ts
@@ -318,28 +318,6 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener> {
 	}
 
 	/**
-	 * More efficient calculation of rectangular coordinates of the port passed in when deltas and zoom are known.
-	 */
-	calculatePortCoords(
-		port: PortModel,
-		deltaX: number,
-		deltaY: number,
-		amountZoom: number
-	): {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-	} {
-		return {
-			x: (port.x + deltaX) / amountZoom,
-			y: (port.y + deltaY) / amountZoom,
-			width: port.width,
-			height: port.height
-		};
-	}
-
-	/**
 	 * Calculate rectangular coordinates of the port passed in.
 	 */
 	getPortCoords(

--- a/src/actions/MoveItemsAction.ts
+++ b/src/actions/MoveItemsAction.ts
@@ -1,8 +1,10 @@
+import * as _ from "lodash";
+
 import { BaseAction } from "./BaseAction";
-import { SelectionModel } from "../models/SelectionModel";
-import { PointModel } from "../models/PointModel";
-import { NodeModel } from "../models/NodeModel";
 import { DiagramEngine } from "../DiagramEngine";
+import { NodeModel } from "../models/NodeModel";
+import { PointModel } from "../models/PointModel";
+import { SelectionModel } from "../models/SelectionModel";
 
 export class MoveItemsAction extends BaseAction {
 	selectionModels: SelectionModel[];
@@ -20,10 +22,18 @@ export class MoveItemsAction extends BaseAction {
 		});
 
 		this.selectionModels = selectedItems.map((item: PointModel | NodeModel) => {
+			const initialPortCoords = {};
+			if (item instanceof NodeModel) {
+				_.forEach(item.getPorts(), port => {
+					initialPortCoords[port.id] = {initialX: port.x, initialY: port.y};
+				})
+			}
+			
 			return {
 				model: item,
 				initialX: item.x,
-				initialY: item.y
+				initialY: item.y,
+				initialPortCoords 
 			};
 		});
 	}

--- a/src/models/SelectionModel.ts
+++ b/src/models/SelectionModel.ts
@@ -1,8 +1,10 @@
 import { BaseModel, BaseModelListener } from "./BaseModel";
+
 import { BaseEntity } from "../BaseEntity";
 
 export interface SelectionModel {
 	model: BaseModel<BaseEntity, BaseModelListener>;
 	initialX: number;
 	initialY: number;
+	initialPortCoords: {[s: string]: {initialX: number, initialY: number}};
 }

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -271,36 +271,57 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 			let amountY = clientY - this.state.action.mouseY;
 			let amountZoom = diagramModel.getZoomLevel() / 100;
 
+			const pointModels = {};
+			
+			_.forEach(this.state.action.selectionModels, model => {
+				if (model.model instanceof PointModel) {
+					pointModels[model.model.id] = model;
+				}
+			});
+
 			_.forEach(this.state.action.selectionModels, model => {
 				// in this case we need to also work out the relative grid position
 				if (
-					model.model instanceof NodeModel ||
-					(model.model instanceof PointModel && !model.model.isConnectedToPort())
+					model.model instanceof NodeModel
 				) {
 					model.model.x = diagramModel.getGridPosition(model.initialX + amountX / amountZoom);
 					model.model.y = diagramModel.getGridPosition(model.initialY + amountY / amountZoom);
+					const diffX =  model.model.x - model.initialX;
+					const diffY =  model.model.y - model.initialY;
 
 					// update port coordinates as well
-					if (model.model instanceof NodeModel) {
+					if (model.model instanceof NodeModel && (diffX !== 0 || diffY !== 0)) {
 						_.forEach(model.model.getPorts(), port => {
-							const portCoords = this.props.diagramEngine.calculatePortCoords(
-								port,
-								amountX,
-								amountY,
-								amountZoom
-							);
-							port.updateCoords(portCoords);
+							
+							const initialPortCoords = model.initialPortCoords[port.id];
+
+							// Update the port coordinates within the node
+							port.updateCoords({
+								x: initialPortCoords.initialX + diffX,
+								y: initialPortCoords.initialY + diffY,
+								width: port.width,
+								height: port.height
+							});
+							
+							// For each link in the node, update the point positions so that the
+							// point (and corresponding link) will move with the node
+							_.forEach(port.getLinks(), link => {
+								const point = link.getPointForPort(port);
+								const pointSelectionModel = pointModels[point.id];
+								point.x = pointSelectionModel.initialX + diffX;
+								point.y = pointSelectionModel.initialY + diffY;
+							})
 						});
 					}
 
 					if (diagramEngine.isSmartRoutingEnabled()) {
 						diagramEngine.calculateRoutingMatrix();
 					}
-				} else if (model.model instanceof PointModel) {
-					// we want points that are connected to ports, to not necessarily snap to grid
+				} else if (model.model instanceof PointModel && !model.model.isConnectedToPort()) {
+					// we want points that are not connected to ports to not snap to grid
 					// this stuff needs to be pixel perfect, dont touch it
-					model.model.x = model.initialX + diagramModel.getGridPosition(amountX / amountZoom);
-					model.model.y = model.initialY + diagramModel.getGridPosition(amountY / amountZoom);
+					model.model.x = model.initialX + amountX / amountZoom;
+					model.model.y = model.initialY + amountY / amountZoom;
 				}
 			});
 

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -281,16 +281,14 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 
 			_.forEach(this.state.action.selectionModels, model => {
 				// in this case we need to also work out the relative grid position
-				if (
-					model.model instanceof NodeModel
-				) {
+				if (model.model instanceof NodeModel) {
 					model.model.x = diagramModel.getGridPosition(model.initialX + amountX / amountZoom);
 					model.model.y = diagramModel.getGridPosition(model.initialY + amountY / amountZoom);
 					const diffX =  model.model.x - model.initialX;
 					const diffY =  model.model.y - model.initialY;
 
 					// update port coordinates as well
-					if (model.model instanceof NodeModel && (diffX !== 0 || diffY !== 0)) {
+					if (diffX !== 0 || diffY !== 0) {
 						_.forEach(model.model.getPorts(), port => {
 							
 							const initialPortCoords = model.initialPortCoords[port.id];


### PR DESCRIPTION
Make sure that points connected to node ports move when the node moves.
Change dragging lines from ports to be pixel perfect and ignore grid snapping.
Properly update port coordinates when moving nodes. This doesn't seem to affect anything (otherwise things would be way off based on previous logic) but it now sets the correct value.

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)
