### PR TITLE
Make the package name consistent with the repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@maana-io/maana-react-diagrams",
+	"name": "@maana-io/react-diagrams",
 	"version": "5.2.15",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
It makes more sense to have the name consistent with the repo path now that we are publishing to github.  This also makes it so that it does not say maana twice in the import name.